### PR TITLE
feat: Limpiar intento actual al usar pista

### DIFF
--- a/app/src/main/java/com/example/palabro/GameViewModel.kt
+++ b/app/src/main/java/com/example/palabro/GameViewModel.kt
@@ -142,7 +142,8 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             _uiState.update {
                 it.copy(
                     revealedHints = newHints,
-                    showHintDialog = false
+                    showHintDialog = false,
+                    currentGuess = ""
                 )
             }
         } else {


### PR DESCRIPTION
Se actualiza onHintConfirm para resetear el currentGuess. Esto mejora la experiencia de usuario al usar una pista, evitando que el jugador tenga que borrar manualmente las letras incorrectas. Closes #11