### PR TITLE
feat(ui): Crear título personalizado

### DIFF
--- a/app/src/main/java/com/example/palabro/GameScreen.kt
+++ b/app/src/main/java/com/example/palabro/GameScreen.kt
@@ -40,13 +40,11 @@ fun GameScreen(gameViewModel: GameViewModel) {
             .padding(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+
+        Spacer(Modifier.height(25.dp))
+
         // Añadimos el título "Palabro"
-        Text(
-            text = "Palabro",
-            style = MaterialTheme.typography.headlineLarge,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(vertical = 8.dp)
-        )
+        GameTitle()
 
         Box(
             modifier = Modifier

--- a/app/src/main/java/com/example/palabro/GameTitle.kt
+++ b/app/src/main/java/com/example/palabro/GameTitle.kt
@@ -1,0 +1,60 @@
+package com.example.palabro
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.palabro.ui.theme.LocalGameColors
+
+/**
+ * Una casilla individual para mostrar una letra del título.
+ */
+@Composable
+private fun TitleLetterBox(letter: Char, color: Color) {
+    Surface(
+        modifier = Modifier.size(38.dp), // Un tamaño más pequeño que las del juego
+        color = color,
+        shape = RoundedCornerShape(8.dp) // Usamos un radio más pequeño
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                text = letter.toString(),
+                fontSize = 22.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color.White
+            )
+        }
+    }
+}
+
+/**
+ * El título completo del juego "Palabro" estilizado.
+ */
+@Composable
+fun GameTitle() {
+    val title = "PALABRO"
+    val gameColors = LocalGameColors.current
+
+    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        title.forEachIndexed { index, letter ->
+            // La última letra ('O') tiene el color de "incorrecto", el resto "correcto".
+            val color = if (index == title.lastIndex) {
+                gameColors.incorrect
+            } else {
+                gameColors.correct
+            }
+            TitleLetterBox(letter = letter, color = color)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.11.1"
+agp = "8.12.0"
 datastorePreferences = "1.1.7"
 kotlin = "2.0.21"
 coreKtx = "1.10.1"


### PR DESCRIPTION
Se crea un nuevo Composable GameTitle que muestra el título "Palabro" usando casillas de colores, haciendo un guiño a la mecánica del juego.